### PR TITLE
Fix SignedHeaders for Scaleway Provider

### DIFF
--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -347,14 +347,15 @@ class AWSRequestSignerAlgorithmV4(AWSRequestSigner):
         )
 
     def _get_signed_headers(self, headers):
-        return ";".join([k.lower() for k in sorted(headers.keys())])
+        return ";".join([k.lower()
+                         for k in sorted(headers.keys(), key=str.lower)])
 
     def _get_canonical_headers(self, headers):
         return (
             "\n".join(
                 [
                     ":".join([k.lower(), str(v).strip()])
-                    for k, v in sorted(headers.items())
+                    for k, v in sorted(headers.items(), key=lambda k: k[0].lower())
                 ]
             )
             + "\n"


### PR DESCRIPTION
## Order headers based on lower string

### Description

Without this patch:
```
Signed headers: accept-encoding;content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-acl;x-amz-meta-created;x-amz-meta-owner;x-amz-storage-class
```

With this patch:
```
Signed headers: accept-encoding;content-type;host;user-agent;x-amz-acl;x-amz-content-sha256;x-amz-date;x-amz-meta-created;x-amz-meta-owner;x-amz-storage-class
```

The sort was done on headers with upper/lower case, this patch fix this
beahiavor.

### Status

Replace this: describe the PR status. Examples:

- work in progress
- done, ready for review


### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
